### PR TITLE
World Parameter by Command Line

### DIFF
--- a/features/support/world.js
+++ b/features/support/world.js
@@ -1,7 +1,7 @@
 const { defineSupportCode } = require('cucumber');
 
-function CustomWorld () {
-  this.apiEndpoint = 'http://play.dhis2.org/dev/api/26/';
+function CustomWorld ({ parameters }) {
+  this.apiEndpoint = parameters.apiEndpoint || 'http://play.dhis2.org/dev/api/26/';
 }
 
 defineSupportCode(function ({setWorldConstructor}) {


### PR DESCRIPTION
The cucumber-js can be executed now like this:
./node_modules/.bin/cucumber-js --world-parameters '{"apiEndpoint": "http://play.dhis2.org/dev/api/26/"}'

If apiEndpoint is not defined the default value will be "http://play.dhis2.org/dev/api/26/".

maybe we should change the npm test command to receive this parameter as well and pass it to cucumber-js command. Not sure if this is possible and how.